### PR TITLE
ci: use openjdk8 instead of oraclejdk8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: java
 jdk:
-  - oraclejdk8
+  - openjdk8
 services:
   - mongodb
 cache:


### PR DESCRIPTION
See https://travis-ci.community/t/install-of-oracle-jdk-8-failing/3038/8